### PR TITLE
docs(web): document prisma generation on install

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,3 +1,3 @@
 # Web
 
-Después de ejecutar `npm install`, corre `npx prisma generate` antes de ejecutar `npm test` para asegurar que el binario de Prisma se descargue correctamente.
+`npm install` ejecuta automáticamente `prisma generate` para descargar el binario correcto del cliente de Prisma en cada instalación. Si necesitas regenerarlo manualmente, puedes ejecutar `npx prisma generate` antes de continuar con otros comandos como `npm test`.


### PR DESCRIPTION
## Summary
- note that `npm install` now runs `prisma generate`
- mention manual `npx prisma generate` option in docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0c25f517883228ecdbba1414bee13